### PR TITLE
feat: Enhance CPU simulation core behavior

### DIFF
--- a/simulator/functional.html
+++ b/simulator/functional.html
@@ -427,6 +427,11 @@ fieldset:hover{background:#eee}textarea,input[type="text"]{border:1px solid #ccc
 			$cpuText.text('Idle');
 		}
 		cpu.reset();
+
+		// ADD for reset
+		lastRegisterFile = new Uint32Array(32); 
+    	lastMemoryBuffer = new Uint32Array(MEMORY_BUFFER_SIZE);
+
 		updateCPUStatus();
 		updateMemoryWindow();
 		updateDisassemblyWindow();


### PR DESCRIPTION
## This PR introduces the following behaviors in the CPU simulator
- Add `syscall` operation
- Remove the requirement for an explicit `not` delay slot following branch/jump instructions
- Revise the reset process to ensure that all registers are correctly reinitialized (ex., 0x00000000). 